### PR TITLE
`SharedMemory` and `ndarray` serialization

### DIFF
--- a/dev-environment.yml
+++ b/dev-environment.yml
@@ -18,6 +18,7 @@ name: appose-dev
 channels:
   - conda-forge
   - defaults
+  - forklift
 dependencies:
   - python >= 3.10
   # Developer tools

--- a/src/appose/__init__.py
+++ b/src/appose/__init__.py
@@ -134,6 +134,7 @@ JSON, one line per request/response.
 from pathlib import Path
 
 from .environment import Builder, Environment
+from .types import NDArray, SharedMemory  # noqa: F401
 
 
 def base(directory: Path) -> Builder:

--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -46,7 +46,7 @@ from typing import Optional
 
 # NB: Avoid relative imports so that this script can be run standalone.
 from appose.service import RequestType, ResponseType
-from appose.types import Args, decode, encode
+from appose.types import Args, _set_worker, decode, encode
 
 
 class Task:
@@ -163,6 +163,8 @@ class Task:
 
 
 def main() -> None:
+    _set_worker(True)
+
     tasks = {}
 
     while True:

--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -87,7 +87,6 @@ class Task:
         def execute_script():
             # Populate script bindings.
             binding = {"task": self}
-            # TODO: Magically convert shared memory image inputs.
             if inputs is not None:
                 binding.update(inputs)
 
@@ -190,8 +189,6 @@ def main() -> None:
             case RequestType.CANCEL:
                 task = tasks.get(uuid)
                 if task is None:
-                    # TODO: proper logging
-                    # Maybe should stdout the error back to Appose calling process.
                     print(f"No such task: {uuid}", file=sys.stderr)
                     continue
                 task.cancel_requested = True

--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -28,7 +28,14 @@
 ###
 
 """
-TODO
+The Appose worker for running Python scripts.
+
+Like all Appose workers, this program conforms to the Appose worker process
+contract, meaning it accepts requests on stdin and produces responses on
+stdout, both formatted according to Appose's assumptions.
+
+For details, see the Appose README:
+https://github.com/apposed/appose/blob/-/README.md#workers
 """
 
 import ast

--- a/src/appose/types.py
+++ b/src/appose/types.py
@@ -43,7 +43,20 @@ def decode(the_json: str) -> Args:
 
 
 class NDArray:
+    """
+    Data structure for a multi-dimensional array.
+    The array contains elements of a data type, arranged in
+    a particular shape, and flattened into SharedMemory.
+    """
+
     def __init__(self, shm: SharedMemory, dtype: str, shape):
+        """
+        Create an NDArray.
+        :param shm: The SharedMemory containing the array data.
+        :param dtype: The type of the data elements; e.g. int8, uint8, float32, float64.
+        :param shape: The dimensional extents; e.g. a stack of 7 image planes
+                      with resolution 512x512 would have shape [7, 512, 512].
+        """
         self.shm = shm
         self.dtype = dtype
         self.shape = shape
@@ -57,6 +70,11 @@ class NDArray:
         )
 
     def ndarray(self):
+        """
+        Create a NumPy ndarray object for working with the array data.
+        No array data is copied; the NumPy array wraps the same SharedMemory.
+        Requires the numpy package to be installed.
+        """
         try:
             import math
 

--- a/src/appose/types.py
+++ b/src/appose/types.py
@@ -37,7 +37,7 @@ Args = Dict[str, Any]
 
 
 def encode(data: Args) -> str:
-    return json.dumps(data)
+    return json.dumps(data, separators=(",", ":"))
 
 
 def decode(the_json: str) -> Args:

--- a/src/appose/types.py
+++ b/src/appose/types.py
@@ -42,7 +42,7 @@ def decode(the_json: str) -> Args:
     return json.loads(the_json, object_hook=_appose_object_hook)
 
 
-class ShmNDArray:
+class NDArray:
     def __init__(self, shm: shared_memory.SharedMemory, dtype: str, shape):
         self.shm = shm
         self.dtype = dtype
@@ -50,7 +50,7 @@ class ShmNDArray:
 
     def __str__(self):
         return (
-            f"ShmNDArray("
+            f"NDArray("
             f"shm='{self.shm.name}' ({self.shm.size}), "
             f"dtype='{self.dtype}', "
             f"shape={self.shape})"
@@ -75,6 +75,6 @@ def _appose_object_hook(obj: Dict):
     if type == "shm":
         return shared_memory.SharedMemory(name=(obj["name"]), size=(obj["size"]))
     elif type == "ndarray":
-        return ShmNDArray(obj["shm"], obj["dtype"], obj["shape"])
+        return NDArray(obj["shm"], obj["dtype"], obj["shape"])
     else:
         return obj

--- a/src/appose/types.py
+++ b/src/appose/types.py
@@ -29,7 +29,7 @@
 
 import json
 from multiprocessing.shared_memory import SharedMemory
-from typing import Any, Dict
+from typing import Any, Dict, Sequence
 
 Args = Dict[str, Any]
 
@@ -49,7 +49,7 @@ class NDArray:
     a particular shape, and flattened into SharedMemory.
     """
 
-    def __init__(self, shm: SharedMemory, dtype: str, shape):
+    def __init__(self, shm: SharedMemory, dtype: str, shape: Sequence[int]):
         """
         Create an NDArray.
         :param shm: The SharedMemory containing the array data.

--- a/src/appose/types.py
+++ b/src/appose/types.py
@@ -28,7 +28,7 @@
 ###
 
 import json
-from multiprocessing import shared_memory
+from multiprocessing.shared_memory import SharedMemory
 from typing import Any, Dict
 
 Args = Dict[str, Any]
@@ -43,7 +43,7 @@ def decode(the_json: str) -> Args:
 
 
 class NDArray:
-    def __init__(self, shm: shared_memory.SharedMemory, dtype: str, shape):
+    def __init__(self, shm: SharedMemory, dtype: str, shape):
         self.shm = shm
         self.dtype = dtype
         self.shape = shape
@@ -73,7 +73,7 @@ class NDArray:
 def _appose_object_hook(obj: Dict):
     type = obj.get("appose_type")
     if type == "shm":
-        return shared_memory.SharedMemory(name=(obj["name"]), size=(obj["size"]))
+        return SharedMemory(name=(obj["name"]), size=(obj["size"]))
     elif type == "ndarray":
         return NDArray(obj["shm"], obj["dtype"], obj["shape"])
     else:

--- a/src/appose/types.py
+++ b/src/appose/types.py
@@ -94,10 +94,10 @@ class NDArray:
 
 
 def _appose_object_hook(obj: Dict):
-    type = obj.get("appose_type")
-    if type == "shm":
+    atype = obj.get("appose_type")
+    if atype == "shm":
         return SharedMemory(name=(obj["name"]), size=(obj["size"]))
-    elif type == "ndarray":
+    elif atype == "ndarray":
         return NDArray(obj["dtype"], obj["shape"], obj["shm"])
     else:
         return obj

--- a/src/appose/types.py
+++ b/src/appose/types.py
@@ -28,8 +28,8 @@
 ###
 
 import json
-from typing import Any, Dict
 from multiprocessing import shared_memory
+from typing import Any, Dict
 
 Args = Dict[str, Any]
 
@@ -43,30 +43,38 @@ def decode(the_json: str) -> Args:
 
 
 class ShmNDArray:
-
-    def __init__(self, shm: shared_memory.SharedMemory, dtype: str, shape ):
+    def __init__(self, shm: shared_memory.SharedMemory, dtype: str, shape):
         self.shm = shm
         self.dtype = dtype
         self.shape = shape
 
     def __str__(self):
-        return f"ShmNDArray(shm='{self.shm.name}' ({self.shm.size}), dtype='{self.dtype}', shape={self.shape})"
+        return (
+            f"ShmNDArray("
+            f"shm='{self.shm.name}' ({self.shm.size}), "
+            f"dtype='{self.dtype}', "
+            f"shape={self.shape})"
+        )
 
     def ndarray(self):
         try:
             import math
+
             import numpy
+
             num_elements = math.prod(self.shape)
-            return numpy.ndarray(num_elements, dtype=self.dtype, buffer=self.shm.buf).reshape(self.shape)
+            return numpy.ndarray(
+                num_elements, dtype=self.dtype, buffer=self.shm.buf
+            ).reshape(self.shape)
         except ModuleNotFoundError:
             raise ImportError("NumPy is not available.")
 
 
 def _appose_object_hook(obj: Dict):
-    type = obj.get('appose_type')
-    if type == 'shm':
-        return shared_memory.SharedMemory(name=(obj['name']), size=(obj['size']))
-    elif type == 'ndarray':
-        return ShmNDArray(obj['shm'], obj['dtype'], obj['shape'])
+    type = obj.get("appose_type")
+    if type == "shm":
+        return shared_memory.SharedMemory(name=(obj["name"]), size=(obj["size"]))
+    elif type == "ndarray":
+        return ShmNDArray(obj["shm"], obj["dtype"], obj["shape"])
     else:
         return obj

--- a/tests/test_shm.py
+++ b/tests/test_shm.py
@@ -27,11 +27,8 @@
 # #L%
 ###
 
-from multiprocessing.shared_memory import SharedMemory
-
 import appose
 from appose.service import TaskStatus
-from appose.types import NDArray
 
 ndarray_inspect = """
 task.outputs["size"] = data.shm.size
@@ -45,11 +42,11 @@ def test_ndarray():
     env = appose.system()
     with env.python() as service:
         # Construct the data.
-        shm = SharedMemory(create=True, size=2 * 2 * 20 * 25)
+        shm = appose.SharedMemory(create=True, size=2 * 2 * 20 * 25)
         shm.buf[0] = 123
         shm.buf[456] = 78
         shm.buf[1999] = 210
-        data = NDArray("uint16", [2, 20, 25], shm)
+        data = appose.NDArray("uint16", [2, 20, 25], shm)
 
         # Run the task.
         task = service.task(ndarray_inspect, {"data": data})

--- a/tests/test_shm.py
+++ b/tests/test_shm.py
@@ -1,0 +1,66 @@
+###
+# #%L
+# Appose: multi-language interprocess cooperation with shared memory.
+# %%
+# Copyright (C) 2023 Appose developers.
+# %%
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# #L%
+###
+
+from multiprocessing.shared_memory import SharedMemory
+
+import appose
+from appose.service import TaskStatus
+from appose.types import NDArray
+
+ndarray_inspect = """
+task.outputs["size"] = data.shm.size
+task.outputs["dtype"] = data.dtype
+task.outputs["shape"] = data.shape
+task.outputs["sum"] = sum(v for v in data.shm.buf)
+"""
+
+
+def test_ndarray():
+    env = appose.system()
+    with env.python() as service:
+        # Construct the data.
+        shm = SharedMemory(create=True, size=2 * 2 * 20 * 25)
+        shm.buf[0] = 123
+        shm.buf[456] = 78
+        shm.buf[1999] = 210
+        data = NDArray("uint16", [2, 20, 25], shm)
+
+        # Run the task.
+        task = service.task(ndarray_inspect, {"data": data})
+        task.wait_for()
+
+        # Validate the execution result.
+        assert TaskStatus.COMPLETE == task.status
+        assert 2 * 20 * 25 * 2 == task.outputs["size"]
+        assert "uint16" == task.outputs["dtype"]
+        assert [2, 20, 25] == task.outputs["shape"]
+        assert 123 + 78 + 210 == task.outputs["sum"]
+
+        # Clean up.
+        shm.unlink()

--- a/tests/test_shm.py
+++ b/tests/test_shm.py
@@ -41,23 +41,20 @@ task.outputs["sum"] = sum(v for v in data.shm.buf)
 def test_ndarray():
     env = appose.system()
     with env.python() as service:
-        # Construct the data.
-        shm = appose.SharedMemory(create=True, size=2 * 2 * 20 * 25)
-        shm.buf[0] = 123
-        shm.buf[456] = 78
-        shm.buf[1999] = 210
-        data = appose.NDArray("uint16", [2, 20, 25], shm)
+        with appose.SharedMemory(create=True, size=2 * 2 * 20 * 25) as shm:
+            # Construct the data.
+            shm.buf[0] = 123
+            shm.buf[456] = 78
+            shm.buf[1999] = 210
+            data = appose.NDArray("uint16", [2, 20, 25], shm)
 
-        # Run the task.
-        task = service.task(ndarray_inspect, {"data": data})
-        task.wait_for()
+            # Run the task.
+            task = service.task(ndarray_inspect, {"data": data})
+            task.wait_for()
 
-        # Validate the execution result.
-        assert TaskStatus.COMPLETE == task.status
-        assert 2 * 20 * 25 * 2 == task.outputs["size"]
-        assert "uint16" == task.outputs["dtype"]
-        assert [2, 20, 25] == task.outputs["shape"]
-        assert 123 + 78 + 210 == task.outputs["sum"]
-
-        # Clean up.
-        shm.unlink()
+            # Validate the execution result.
+            assert TaskStatus.COMPLETE == task.status
+            assert 2 * 20 * 25 * 2 == task.outputs["size"]
+            assert "uint16" == task.outputs["dtype"]
+            assert [2, 20, 25] == task.outputs["shape"]
+            assert 123 + 78 + 210 == task.outputs["sum"]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,4 @@
 import unittest
-from multiprocessing.shared_memory import SharedMemory
 
 import appose
 
@@ -66,7 +65,7 @@ class TypesTest(unittest.TestCase):
             "numbers": self.NUMBERS,
             "words": self.WORDS,
         }
-        ndarray = appose.types.NDArray("float32", [2, 20, 25])
+        ndarray = appose.NDArray("float32", [2, 20, 25])
         shm_name = ndarray.shm.name
         data["ndArray"] = ndarray
         json_str = appose.types.encode(data)
@@ -76,7 +75,7 @@ class TypesTest(unittest.TestCase):
         ndarray.shm.unlink()
 
     def test_decode(self):
-        shm = SharedMemory(create=True, size=4000)
+        shm = appose.SharedMemory(create=True, size=4000)
         shm_name = shm.name
         data = appose.types.decode(self.JSON.replace("SHM_NAME", shm_name))
         self.assertIsNotNone(data)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,81 @@
+import unittest
+
+import appose
+
+
+class TypesTest(unittest.TestCase):
+    JSON = (
+        "{"
+        '"posByte":123,"negByte":-98,'
+        '"posDouble":9.876543210123456,"negDouble":-1.234567890987654e+302,'
+        '"posFloat":9.876543,"negFloat":-1.2345678,'
+        '"posInt":1234567890,"negInt":-987654321,'
+        '"posLong":12345678987654321,"negLong":-98765432123456789,'
+        '"posShort":32109,"negShort":-23456,'
+        '"trueBoolean":true,"falseBoolean":false,'
+        '"nullChar":"\\u0000",'
+        '"aString":"-=[]\\\\;\',./_+{}|:\\"<>?'
+        "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz"
+        '~!@#$%^&*()",'
+        '"numbers":[1,1,2,3,5,8],'
+        '"words":["quick","brown","fox"]'
+        "}"
+    )
+
+    STRING = (
+        "-=[]\\;',./_+{}|:\"<>?"
+        "AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz"
+        "~!@#$%^&*()"
+    )
+
+    NUMBERS = [1, 1, 2, 3, 5, 8]
+
+    WORDS = ["quick", "brown", "fox"]
+
+    def test_encode(self):
+        data = {
+            "posByte": 123,
+            "negByte": -98,
+            "posDouble": 9.876543210123456,
+            "negDouble": -1.234567890987654e302,
+            "posFloat": 9.876543,
+            "negFloat": -1.2345678,
+            "posInt": 1234567890,
+            "negInt": -987654321,
+            "posLong": 12345678987654321,
+            "negLong": -98765432123456789,
+            "posShort": 32109,
+            "negShort": -23456,
+            "trueBoolean": True,
+            "falseBoolean": False,
+            "nullChar": "\0",
+            "aString": self.STRING,
+            "numbers": self.NUMBERS,
+            "words": self.WORDS,
+        }
+        json_str = appose.types.encode(data)
+        self.assertIsNotNone(json_str)
+        self.assertEqual(self.JSON, json_str)
+
+    def test_decode(self):
+        data = appose.types.decode(self.JSON)
+        self.assertIsNotNone(data)
+        self.assertEqual(18, len(data))
+        self.assertEqual(123, data["posByte"])
+        self.assertEqual(-98, data["negByte"])
+        self.assertEqual(9.876543210123456, data["posDouble"])
+        self.assertEqual(-1.234567890987654e302, data["negDouble"])
+        self.assertEqual(9.876543, data["posFloat"])
+        self.assertEqual(-1.2345678, data["negFloat"])
+        self.assertEqual(1234567890, data["posInt"])
+        self.assertEqual(-987654321, data["negInt"])
+        self.assertEqual(12345678987654321, data["posLong"])
+        self.assertEqual(-98765432123456789, data["negLong"])
+        self.assertEqual(32109, data["posShort"])
+        self.assertEqual(-23456, data["negShort"])
+        self.assertTrue(data["trueBoolean"])
+        self.assertFalse(data["falseBoolean"])
+        self.assertEqual("\0", data["nullChar"])
+        self.assertEqual(self.STRING, data["aString"])
+        self.assertEqual(self.NUMBERS, data["numbers"])
+        self.assertEqual(self.WORDS, data["words"])

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -65,40 +65,38 @@ class TypesTest(unittest.TestCase):
             "numbers": self.NUMBERS,
             "words": self.WORDS,
         }
-        ndarray = appose.NDArray("float32", [2, 20, 25])
-        shm_name = ndarray.shm.name
-        data["ndArray"] = ndarray
-        json_str = appose.types.encode(data)
-        self.assertIsNotNone(json_str)
-        expected = self.JSON.replace("SHM_NAME", shm_name)
-        self.assertEqual(expected, json_str)
-        ndarray.shm.unlink()
+        with appose.NDArray("float32", [2, 20, 25]) as ndarray:
+            shm_name = ndarray.shm.name
+            data["ndArray"] = ndarray
+            json_str = appose.types.encode(data)
+            self.assertIsNotNone(json_str)
+            expected = self.JSON.replace("SHM_NAME", shm_name)
+            self.assertEqual(expected, json_str)
 
     def test_decode(self):
-        shm = appose.SharedMemory(create=True, size=4000)
-        shm_name = shm.name
-        data = appose.types.decode(self.JSON.replace("SHM_NAME", shm_name))
-        self.assertIsNotNone(data)
-        self.assertEqual(19, len(data))
-        self.assertEqual(123, data["posByte"])
-        self.assertEqual(-98, data["negByte"])
-        self.assertEqual(9.876543210123456, data["posDouble"])
-        self.assertEqual(-1.234567890987654e302, data["negDouble"])
-        self.assertEqual(9.876543, data["posFloat"])
-        self.assertEqual(-1.2345678, data["negFloat"])
-        self.assertEqual(1234567890, data["posInt"])
-        self.assertEqual(-987654321, data["negInt"])
-        self.assertEqual(12345678987654321, data["posLong"])
-        self.assertEqual(-98765432123456789, data["negLong"])
-        self.assertEqual(32109, data["posShort"])
-        self.assertEqual(-23456, data["negShort"])
-        self.assertTrue(data["trueBoolean"])
-        self.assertFalse(data["falseBoolean"])
-        self.assertEqual("\0", data["nullChar"])
-        self.assertEqual(self.STRING, data["aString"])
-        self.assertEqual(self.NUMBERS, data["numbers"])
-        self.assertEqual(self.WORDS, data["words"])
-        ndArray = data["ndArray"]
-        self.assertEqual("float32", ndArray.dtype)
-        self.assertEqual([2, 20, 25], ndArray.shape)
-        shm.unlink()
+        with appose.SharedMemory(create=True, size=4000) as shm:
+            shm_name = shm.name
+            data = appose.types.decode(self.JSON.replace("SHM_NAME", shm_name))
+            self.assertIsNotNone(data)
+            self.assertEqual(19, len(data))
+            self.assertEqual(123, data["posByte"])
+            self.assertEqual(-98, data["negByte"])
+            self.assertEqual(9.876543210123456, data["posDouble"])
+            self.assertEqual(-1.234567890987654e302, data["negDouble"])
+            self.assertEqual(9.876543, data["posFloat"])
+            self.assertEqual(-1.2345678, data["negFloat"])
+            self.assertEqual(1234567890, data["posInt"])
+            self.assertEqual(-987654321, data["negInt"])
+            self.assertEqual(12345678987654321, data["posLong"])
+            self.assertEqual(-98765432123456789, data["negLong"])
+            self.assertEqual(32109, data["posShort"])
+            self.assertEqual(-23456, data["negShort"])
+            self.assertTrue(data["trueBoolean"])
+            self.assertFalse(data["falseBoolean"])
+            self.assertEqual("\0", data["nullChar"])
+            self.assertEqual(self.STRING, data["aString"])
+            self.assertEqual(self.NUMBERS, data["numbers"])
+            self.assertEqual(self.WORDS, data["words"])
+            ndArray = data["ndArray"]
+            self.assertEqual("float32", ndArray.dtype)
+            self.assertEqual([2, 20, 25], ndArray.shape)


### PR DESCRIPTION
This PR adds a class `ShmNDArray` that annotates SharedMemory with dtype and shape.
If NumPy is available `ShmNDArray.ndarray()` provides a `numpy.ndarray` view.

See this [usage example](https://github.com/apposed/appose-java/blob/65ed5cf2227b29605e390b65a8ca3ad55ede238e/src/test/java/org/apposed/appose/NDArrayExamplePython.java) in the corresponding https://github.com/apposed/appose-java/pull/5 PR.

