### PR TITLE
Improvement of Python `exec` for global name-spacing

### DIFF
--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -183,9 +183,7 @@ def main() -> None:
         while running:
             sleep(0.05)
             dead = {
-                uuid: task
-                for uuid, task in tasks.items()
-                if not task.thread.is_alive()
+                uuid: task for uuid, task in tasks.items() if not task.thread.is_alive()
             }
             for uuid, task in dead.items():
                 tasks.pop(uuid)

--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -113,7 +113,14 @@ class Task:
                     # Last statement of the script looks like an expression. Evaluate!
                     last = ast.Expression(block.body.pop().value)
 
-                _globals = {}
+                # NB: When `exec` gets two separate objects as *globals* and
+                # *locals*, the code will be executed as if it were embedded in
+                # a class definition. This means functions and classes defined
+                # in the executed code will not be able to access variables
+                # assigned at the top level, because the "top level" variables
+                # are treated as class variables in a class definition.
+                # See: https://docs.python.org/3/library/functions.html#exec
+                _globals = binding
                 exec(compile(block, "<string>", mode="exec"), _globals, binding)
                 if last is not None:
                     result = eval(

--- a/src/appose/service.py
+++ b/src/appose/service.py
@@ -259,6 +259,7 @@ class ResponseType(Enum):
     """
     True iff response type is COMPLETE, CANCELED, FAILED, or CRASHED.
     """
+
     def is_terminal(self):
         return self in (
             ResponseType.COMPLETION,

--- a/tests/test_appose.py
+++ b/tests/test_appose.py
@@ -55,6 +55,13 @@ while v != 1:
 task.outputs["result"] = time
 """
 
+sqrt_import = """
+from math import sqrt
+def sqrt_age(age):
+    return sqrt(age)
+task.outputs["result"] = sqrt_age(age)
+"""
+
 
 def test_groovy():
     env = appose.system()
@@ -81,6 +88,16 @@ def test_service_startup_failure():
             "['java', 'java.exe', 'bin/java', 'bin/java.exe', "
             "'jre/bin/java', 'jre/bin/java.exe']"
         ) == str(e)
+
+
+def test_scope():
+    env = appose.system()
+    with env.python() as service:
+        task = service.task(sqrt_import, {"age": 100})
+        task.start()
+        task.wait_for()
+        result = round(task.outputs.get("result"))
+        assert result == 10
 
 
 def execute_and_assert(service: Service, script: str):


### PR DESCRIPTION
When executing parsed functions with Python's `exec(script, global=x, local=y)`, the parameters needs to be specified such that x == y. If not, modules/attributes defined in `script` will not be added to their global namespace.

This PR fixes this problem and adds a test-case.

See here for background:
[#Appose > Getting Started with Fiji-Appose @ 💬](https://imagesc.zulipchat.com/#narrow/channel/377693-Appose/topic/Getting.20Started.20with.20Fiji-Appose/near/507035117)

And here for documentation:
https://docs.python.org/3/library/functions.html#exec

>When exec gets two separate objects as globals and locals, the code will be executed as if it were embedded in a class definition. This means functions and classes defined in the executed code will not be able to access variables assigned at the top level (as the “top level” variables are treated as class variables in a class definition). 