### PR TITLE
Always initialize thread attribute

### DIFF
--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -56,6 +56,7 @@ class Task:
         self.outputs = {}
         self.finished = False
         self.cancel_requested = False
+        self.thread = None  # Initialize thread attribute
 
     def update(
         self,
@@ -190,7 +191,7 @@ def main() -> None:
         while running:
             sleep(0.05)
             dead = {
-                uuid: task for uuid, task in tasks.items() if not task.thread.is_alive()
+                uuid: task for uuid, task in tasks.items() if task.thread is not None and not task.thread.is_alive()
             }
             for uuid, task in dead.items():
                 tasks.pop(uuid)


### PR DESCRIPTION
In the cleanup_threads() function, it could happen that tasks exist that have not been started. In this case the variable thread was not initialized leading to an attribute error.

This PR fixes this situation by always explictly initializing the thread attribute.
