### PR TITLE
Conda clash - add variable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "appose"
-version = "0.12.0.dev0"
+version = "0.12.0.dev1"
 description = "Appose: multi-language interprocess cooperation with shared memory."
 license = "BSD-2-Clause"
 authors = [{name = "Appose developers"}]

--- a/src/appose/environment.py
+++ b/src/appose/environment.py
@@ -149,7 +149,7 @@ class Environment:
         # NB: Unset conda/mamba variables so they don't bleed into the worker
         # process and cause the wrong Python interpreter to be resolved.
         # Only clear variables not explicitly set by the caller via env().
-        conda_vars = ("CONDA_PREFIX", "CONDA_DEFAULT_ENV", "CONDA_SHLVL")
+        conda_vars = ("CONDA_PREFIX", "CONDA_DEFAULT_ENV", "CONDA_SHLVL", "PYTHONEXECUTABLE")
         explicit = self.env_vars()
         conda_unset = {var: None for var in conda_vars if var not in explicit}
         return (


### PR DESCRIPTION
Added PYTHONEXECUTABLE to the variables list to not bleed to the worker 