### PR TITLE
Fix spurious "thread death" TOCTOU race in python_worker

### DIFF
--- a/src/appose/python_worker.py
+++ b/src/appose/python_worker.py
@@ -222,8 +222,15 @@ class Worker:
                 else:
                     # Create a thread and save a reference to it, in case its script
                     # kills the thread. This happens e.g. if it calls sys.exit.
-                    task._thread = Thread(target=task._run, name=f"Appose-{uuid}")
-                    task._thread.start()
+                    #
+                    # Assign task._thread only AFTER start() returns. Otherwise the
+                    # janitor (_cleanup_threads) can observe task._thread set while
+                    # the thread is not yet alive (the window between Thread()
+                    # construction and start()) and spuriously fail the task with
+                    # "thread death". See apposed/appose#15.
+                    t = Thread(target=task._run, name=f"Appose-{uuid}")
+                    t.start()
+                    task._thread = t
 
             elif request_type == RequestType.CANCEL:
                 task = self.tasks.get(uuid)

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -7,6 +7,7 @@ import appose
 from appose.service import ResponseType, TaskException, TaskStatus
 from tests.test_base import execute_and_assert, maybe_debug
 from pathlib import Path
+import threading
 import time
 import os
 import re
@@ -354,3 +355,39 @@ def test_task_result_null():
 
         # result() should return None.
         assert task.result() is None
+
+
+def test_thread_death_stress():
+    """Floods the worker with many concurrent tiny tasks to surface the
+    spurious 'thread death' race (apposed/appose#15). No task here can
+    legitimately die, so any 'thread death' is the bug."""
+    env = appose.system()
+    n_threads = 16
+    n_tasks = 200  # per thread
+    errors = []
+    err_lock = threading.Lock()
+    submit_lock = threading.Lock()  # serialize stdin writes only
+
+    with env.python() as service:
+        maybe_debug(service)
+
+        def worker():
+            for _ in range(n_tasks):
+                with submit_lock:
+                    task = service.task("task.outputs['result'] = 1")
+                    task.start()
+                try:
+                    task.wait_for()
+                except Exception as e:
+                    with err_lock:
+                        errors.append(str(e))
+
+        threads = [threading.Thread(target=worker) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    assert not errors, (
+        f"{len(errors)}/{n_threads * n_tasks} tasks failed; sample: {errors[:5]}"
+    )


### PR DESCRIPTION
## Summary

Fixes the sporadic spurious "thread death" task failures reported in https://github.com/apposed/appose/issues/15.

## Root cause

In `Worker._process_input()`, non-main tasks were wired up as:

```python
task._thread = Thread(target=task._run, name=f"Appose-{uuid}")
task._thread.start()
```

`task._thread` is assigned before `start()` is called. The janitor thread `_cleanup_threads()` flags any task where `task._thread is not None` and `not task._thread.is_alive()`. A just-constructed, not-yet-started thread is not alive, so if the janitor's 0.05s poll lands in the window between `Thread()` construction and `start()`, it wrongly fails the task with "thread death" — even though the thread is about to run fine.

## Fix

Build the thread into a local, start it, and assign `task._thread` only after `start()` returns, so the janitor can never observe a referenced thread that isn't yet alive:

```python
t = Thread(target=task._run, name=f"Appose-{uuid}")
t.start()
task._thread = t
```

## Reproduction & verification

Added `test_thread_death_stress`, which floods the worker with 16 threads × 200 tiny tasks (none of which can legitimately die), so any "thread death" is the bug.

- **Before the fix:** failed on every run (e.g. 5/3200, 8/3200, 4/3200 tasks failing, all with "thread death").
- **After the fix:** passes consistently (6/6 consecutive runs green).

Full `tests/test_service.py` Python suite passes with no regressions, including `test_python_sys_exit` (a genuine `sys.exit` in a task is now caught and reported as `SystemExit: 123`, which the test allows). 
