### PR TITLE
handles ndarray type parsing for types in short notation with bytes

### DIFF
--- a/src/appose/shm.py
+++ b/src/appose/shm.py
@@ -189,9 +189,9 @@ message.register(
 
 def _bytes_per_element(dtype: str) -> int | float:
     """
-        Returns the number of bytes for the given type name
-        The type name can be standard, e.g. uint16, float32... in that case, parsing the number in the string gives the number of bits, to divide by 8.
-        The type name can also be a short version with bytes numbers, e.g. >u2, <f4... Parsing gives directly the nb of bytes
+    Returns the number of bytes for the given type name
+    The type name can be standard, e.g. uint16, float32... in that case, parsing the number in the string gives the number of bits, to divide by 8.
+    The type name can also be a short version with bytes numbers, e.g. >u2, <f4... Parsing gives directly the nb of bytes
     """
     try:
         # Standard names (e.g., 'uint16', 'float32')
@@ -203,4 +203,5 @@ def _bytes_per_element(dtype: str) -> int | float:
             bytes_size = int(re.sub("[^0-9]", "", dtype))
     except ValueError:
         raise ValueError(f"Invalid dtype: {dtype}")
-    return bytes_size 
+
+    return bytes_size

--- a/src/appose/shm.py
+++ b/src/appose/shm.py
@@ -194,8 +194,11 @@ def _bytes_per_element(dtype: str) -> int | float:
     The type name can also be a short version with bytes numbers, e.g. >u2, <f4... Parsing gives directly the nb of bytes
     """
     try:
+        ## boolean object should be one byte 
+        if dtype.startswith("bool"):
+            bytes_size = 1
         # Standard names (e.g., 'uint16', 'float32')
-        if dtype.startswith(("uint", "int", "float", "bool", "complex")):
+        elif dtype.startswith(("uint", "int", "float", "complex")):
             bits = int(re.sub("[^0-9]", "", dtype))
             bytes_size = bits / 8
         # Short names (e.g., '>u2', '<f4', '|u1')

--- a/src/appose/shm.py
+++ b/src/appose/shm.py
@@ -194,7 +194,7 @@ def _bytes_per_element(dtype: str) -> int | float:
     The type name can also be a short version with bytes numbers, e.g. >u2, <f4... Parsing gives directly the nb of bytes
     """
     try:
-        ## boolean object should be one byte 
+        ## boolean object should be one byte
         if dtype.startswith("bool"):
             bytes_size = 1
         # Standard names (e.g., 'uint16', 'float32')

--- a/src/appose/shm.py
+++ b/src/appose/shm.py
@@ -188,8 +188,19 @@ message.register(
 
 
 def _bytes_per_element(dtype: str) -> int | float:
+    """
+        Returns the number of bytes for the given type name
+        The type name can be standard, e.g. uint16, float32... in that case, parsing the number in the string gives the number of bits, to divide by 8.
+        The type name can also be a short version with bytes numbers, e.g. >u2, <f4... Parsing gives directly the nb of bytes
+    """
     try:
-        bits = int(re.sub("[^0-9]", "", dtype))
+        # Standard names (e.g., 'uint16', 'float32')
+        if dtype.startswith(("uint", "int", "float", "bool", "complex")):
+            bits = int(re.sub("[^0-9]", "", dtype))
+            bytes_size = bits / 8
+        # Short names (e.g., '>u2', '<f4', '|u1')
+        else:
+            bytes_size = int(re.sub("[^0-9]", "", dtype))
     except ValueError:
         raise ValueError(f"Invalid dtype: {dtype}")
-    return bits / 8
+    return bytes_size 


### PR DESCRIPTION
In NDArray() function, dtype str can be a short notation in bytes instead of bits (more standard). Handles that case by not dividing by 8 when it's not a standard notation.
